### PR TITLE
feat: add OpenCV ONNX segmentation example

### DIFF
--- a/examples/YOLO11-Segmentation-OpenCV-ONNX-Python/README.md
+++ b/examples/YOLO11-Segmentation-OpenCV-ONNX-Python/README.md
@@ -1,0 +1,38 @@
+# Ultralytics YOLO11 Segmentation with OpenCV and ONNX
+
+This example demonstrates how to perform instance segmentation using a [Ultralytics YOLO11](https://docs.ultralytics.com/models/yolo11/) model exported to the [ONNX](https://onnx.ai/) format and executed with [OpenCV](https://opencv.org/) 4.8 or newer.
+
+## 🚀 Getting Started
+
+1. **Clone the Repository**
+
+   ```bash
+   git clone https://github.com/ultralytics/ultralytics.git
+   cd ultralytics/examples/YOLO11-Segmentation-OpenCV-ONNX-Python
+   ```
+
+2. **Install Requirements**
+
+   ```bash
+   pip install opencv-python>=4.8 ultralytics
+   ```
+
+3. **Export Your Model**
+
+   If you have a trained YOLO11 segmentation model (`yolo11n-seg.pt` for example), export it to ONNX with:
+
+   ```bash
+   yolo export model=yolo11n-seg.pt format=onnx opset=12
+   ```
+
+4. **Run the Segmentation Script**
+
+   ```bash
+   python main.py --model yolo11n-seg.onnx --source path/to/image.jpg
+   ```
+
+   The script will display the image with predicted masks and bounding boxes.
+
+## 🤝 Contributing
+
+Contributions are welcome! Feel free to open an issue or submit a pull request with improvements or bug fixes.

--- a/examples/YOLO11-Segmentation-OpenCV-ONNX-Python/README.md
+++ b/examples/YOLO11-Segmentation-OpenCV-ONNX-Python/README.md
@@ -13,13 +13,16 @@ This example demonstrates how to perform instance segmentation using a [Ultralyt
 
 2. **Install Requirements**
 
+   Only OpenCV (for ONNX inference) and NumPy are required:
+
    ```bash
-   pip install opencv-python>=4.8 ultralytics
+   pip install opencv-python>=4.8 numpy
    ```
 
 3. **Export Your Model**
 
-   If you have a trained YOLO11 segmentation model (`yolo11n-seg.pt` for example), export it to ONNX with:
+   If you have a trained YOLO11 segmentation model (`yolo11n-seg.pt` for example), export it to ONNX using the
+   [Ultralytics](https://github.com/ultralytics/ultralytics) CLI (which requires PyTorch) in a separate environment:
 
    ```bash
    yolo export model=yolo11n-seg.pt format=onnx opset=12

--- a/examples/YOLO11-Segmentation-OpenCV-ONNX-Python/main.py
+++ b/examples/YOLO11-Segmentation-OpenCV-ONNX-Python/main.py
@@ -1,0 +1,107 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+"""YOLO11 segmentation inference using OpenCV and ONNX."""
+
+import argparse
+from typing import List, Tuple, Union
+
+import cv2
+import numpy as np
+import torch
+
+import ultralytics.utils.ops as ops
+from ultralytics.engine.results import Results
+from ultralytics.utils import ASSETS, YAML
+from ultralytics.utils.checks import check_yaml
+
+
+class YOLO11Seg:
+    """YOLO11 segmentation model for performing instance segmentation with OpenCV."""
+
+    def __init__(
+        self,
+        onnx_model: str,
+        conf: float = 0.25,
+        iou: float = 0.7,
+        imgsz: Union[int, Tuple[int, int]] = 640,
+    ) -> None:
+        """Initialise segmentation model with given ONNX weights."""
+        self.net = cv2.dnn.readNetFromONNX(onnx_model)
+        self.imgsz = (imgsz, imgsz) if isinstance(imgsz, int) else imgsz
+        self.classes = YAML.load(check_yaml("coco8.yaml"))["names"]
+        self.conf = conf
+        self.iou = iou
+
+    def __call__(self, img: np.ndarray) -> List[Results]:
+        """Run inference on a single image."""
+        prep_img = self.preprocess(img, self.imgsz)
+        self.net.setInput(prep_img)
+        preds, protos = self.net.forward(["output0", "output1"])
+        preds = torch.from_numpy(np.squeeze(preds).T).unsqueeze(0)
+        protos = torch.from_numpy(protos)
+        return self.postprocess(img, prep_img, [preds, protos])
+
+    @staticmethod
+    def letterbox(img: np.ndarray, new_shape: Tuple[int, int]) -> np.ndarray:
+        """Resize and pad image while meeting stride-multiple constraints."""
+        shape = img.shape[:2]
+        r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
+        new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
+        dw, dh = (new_shape[1] - new_unpad[0]) / 2, (new_shape[0] - new_unpad[1]) / 2
+        if shape[::-1] != new_unpad:
+            img = cv2.resize(img, new_unpad, interpolation=cv2.INTER_LINEAR)
+        top, bottom = int(round(dh - 0.1)), int(round(dh + 0.1))
+        left, right = int(round(dw - 0.1)), int(round(dw + 0.1))
+        img = cv2.copyMakeBorder(img, top, bottom, left, right, cv2.BORDER_CONSTANT, value=(114, 114, 114))
+        return img
+
+    def preprocess(self, img: np.ndarray, new_shape: Tuple[int, int]) -> np.ndarray:
+        """Prepare image for inference."""
+        img = self.letterbox(img, new_shape)
+        img = img[..., ::-1].transpose([2, 0, 1])[None]
+        img = np.ascontiguousarray(img, dtype=np.float32) / 255.0
+        return img
+
+    def postprocess(self, img: np.ndarray, prep_img: np.ndarray, outs: List[torch.Tensor]) -> List[Results]:
+        """Process model outputs into `Results` objects."""
+        preds, protos = outs
+        preds = ops.non_max_suppression(preds, self.conf, self.iou, nc=len(self.classes))
+        results = []
+        for i, pred in enumerate(preds):
+            if not len(pred):
+                results.append(Results(img, path="", names=self.classes, boxes=pred[:, :6], masks=torch.zeros(0, *img.shape[:2])))
+                continue
+            pred[:, :4] = ops.scale_boxes(prep_img.shape[2:], pred[:, :4], img.shape)
+            masks = self.process_mask(protos[i], pred[:, 6:], pred[:, :4], img.shape[:2])
+            results.append(Results(img, path="", names=self.classes, boxes=pred[:, :6], masks=masks))
+        return results
+
+    def process_mask(
+        self, protos: torch.Tensor, masks_in: torch.Tensor, bboxes: torch.Tensor, shape: Tuple[int, int]
+    ) -> torch.Tensor:
+        """Generate masks from mask coefficients and prototypes."""
+        c, mh, mw = protos.shape
+        masks = (masks_in @ protos.float().view(c, -1)).view(-1, mh, mw)
+        masks = ops.scale_masks(masks[None], shape)[0]
+        masks = ops.crop_mask(masks, bboxes)
+        return masks.gt_(0.0)
+
+
+def main(onnx_model: str, source: str, conf: float = 0.25, iou: float = 0.7) -> List[Results]:
+    """Run YOLO11 segmentation inference using OpenCV."""
+    model = YOLO11Seg(onnx_model, conf, iou)
+    img = cv2.imread(source)
+    results = model(img)
+    cv2.imshow("Segmented Image", results[0].plot())
+    cv2.waitKey(0)
+    cv2.destroyAllWindows()
+    return results
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, required=True, help="Path to ONNX model")
+    parser.add_argument("--source", type=str, default=str(ASSETS / "bus.jpg"), help="Path to input image")
+    parser.add_argument("--conf", type=float, default=0.25, help="Confidence threshold")
+    parser.add_argument("--iou", type=float, default=0.7, help="NMS IoU threshold")
+    args = parser.parse_args()
+    main(args.model, args.source, args.conf, args.iou)

--- a/examples/YOLO11-Segmentation-OpenCV-ONNX-Python/main.py
+++ b/examples/YOLO11-Segmentation-OpenCV-ONNX-Python/main.py
@@ -1,17 +1,11 @@
-# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
-"""YOLO11 segmentation inference using OpenCV and ONNX."""
+# Ultralytics AGPL-3.0 License - https://ultralytics.com/license
+"""YOLO11 segmentation inference using only OpenCV and NumPy."""
 
 import argparse
-from typing import List, Tuple, Union
+from typing import Tuple, Union
 
 import cv2
 import numpy as np
-import torch
-
-import ultralytics.utils.ops as ops
-from ultralytics.engine.results import Results
-from ultralytics.utils import ASSETS, YAML
-from ultralytics.utils.checks import check_yaml
 
 
 class YOLO11Seg:
@@ -27,21 +21,18 @@ class YOLO11Seg:
         """Initialise segmentation model with given ONNX weights."""
         self.net = cv2.dnn.readNetFromONNX(onnx_model)
         self.imgsz = (imgsz, imgsz) if isinstance(imgsz, int) else imgsz
-        self.classes = YAML.load(check_yaml("coco8.yaml"))["names"]
         self.conf = conf
         self.iou = iou
 
-    def __call__(self, img: np.ndarray) -> List[Results]:
+    def __call__(self, img: np.ndarray):
         """Run inference on a single image."""
-        prep_img = self.preprocess(img, self.imgsz)
-        self.net.setInput(prep_img)
+        prep, ratio, dwdh, _ = self.preprocess(img, self.imgsz)
+        self.net.setInput(prep)
         preds, protos = self.net.forward(["output0", "output1"])
-        preds = torch.from_numpy(np.squeeze(preds).T).unsqueeze(0)
-        protos = torch.from_numpy(protos)
-        return self.postprocess(img, prep_img, [preds, protos])
+        return self.postprocess(img, preds, protos, ratio, dwdh)
 
     @staticmethod
-    def letterbox(img: np.ndarray, new_shape: Tuple[int, int]) -> np.ndarray:
+    def letterbox(img: np.ndarray, new_shape: Tuple[int, int]):
         """Resize and pad image while meeting stride-multiple constraints."""
         shape = img.shape[:2]
         r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
@@ -52,55 +43,118 @@ class YOLO11Seg:
         top, bottom = int(round(dh - 0.1)), int(round(dh + 0.1))
         left, right = int(round(dw - 0.1)), int(round(dw + 0.1))
         img = cv2.copyMakeBorder(img, top, bottom, left, right, cv2.BORDER_CONSTANT, value=(114, 114, 114))
-        return img
+        return img, r, (dw, dh), new_unpad
 
-    def preprocess(self, img: np.ndarray, new_shape: Tuple[int, int]) -> np.ndarray:
+    def preprocess(self, img: np.ndarray, new_shape: Tuple[int, int]):
         """Prepare image for inference."""
-        img = self.letterbox(img, new_shape)
-        img = img[..., ::-1].transpose([2, 0, 1])[None]
+        img, r, dwdh, new_unpad = self.letterbox(img, new_shape)
+        img = img[..., ::-1].transpose(2, 0, 1)[None]
         img = np.ascontiguousarray(img, dtype=np.float32) / 255.0
-        return img
+        return img, r, dwdh, new_unpad
 
-    def postprocess(self, img: np.ndarray, prep_img: np.ndarray, outs: List[torch.Tensor]) -> List[Results]:
-        """Process model outputs into `Results` objects."""
-        preds, protos = outs
-        preds = ops.non_max_suppression(preds, self.conf, self.iou, nc=len(self.classes))
-        results = []
-        for i, pred in enumerate(preds):
-            if not len(pred):
-                results.append(Results(img, path="", names=self.classes, boxes=pred[:, :6], masks=torch.zeros(0, *img.shape[:2])))
-                continue
-            pred[:, :4] = ops.scale_boxes(prep_img.shape[2:], pred[:, :4], img.shape)
-            masks = self.process_mask(protos[i], pred[:, 6:], pred[:, :4], img.shape[:2])
-            results.append(Results(img, path="", names=self.classes, boxes=pred[:, :6], masks=masks))
-        return results
+    def postprocess(self, img: np.ndarray, preds: np.ndarray, protos: np.ndarray, ratio: float, dwdh):
+        """Process model outputs returning boxes, masks, class ids and confidences."""
+        preds = np.squeeze(preds).T
+        protos = np.squeeze(protos)
+        nm = protos.shape[0]
+        nc = preds.shape[1] - nm - 4
+        boxes = preds[:, :4]
+        scores = preds[:, 4 : 4 + nc]
+        masks_in = preds[:, 4 + nc :]
+        class_ids = scores.argmax(1)
+        scores = scores[np.arange(scores.shape[0]), class_ids]
+        keep = scores > self.conf
+        boxes, scores, class_ids, masks_in = boxes[keep], scores[keep], class_ids[keep], masks_in[keep]
+        if not boxes.size:
+            return [], [], [], []
 
-    def process_mask(
-        self, protos: torch.Tensor, masks_in: torch.Tensor, bboxes: torch.Tensor, shape: Tuple[int, int]
-    ) -> torch.Tensor:
+        boxes_xyxy = np.zeros_like(boxes)
+        boxes_xyxy[:, 0] = boxes[:, 0] - boxes[:, 2] / 2
+        boxes_xyxy[:, 1] = boxes[:, 1] - boxes[:, 3] / 2
+        boxes_xyxy[:, 2] = boxes[:, 0] + boxes[:, 2] / 2
+        boxes_xyxy[:, 3] = boxes[:, 1] + boxes[:, 3] / 2
+
+        boxes_nms = boxes_xyxy.copy()
+        boxes_nms[:, 2] -= boxes_nms[:, 0]
+        boxes_nms[:, 3] -= boxes_nms[:, 1]
+        indices = cv2.dnn.NMSBoxes(boxes_nms.tolist(), scores.tolist(), self.conf, self.iou)
+        if len(indices):
+            indices = np.array(indices).reshape(-1)
+            boxes_xyxy = boxes_xyxy[indices]
+            scores = scores[indices]
+            class_ids = class_ids[indices]
+            masks_in = masks_in[indices]
+        else:
+            return [], [], [], []
+
+        boxes_xyxy = self.scale_boxes(boxes_xyxy, ratio, dwdh, img.shape)
+        masks = self.process_mask(protos, masks_in, boxes_xyxy, img.shape, ratio, dwdh)
+        return boxes_xyxy, masks, class_ids, scores
+
+    @staticmethod
+    def scale_boxes(boxes, ratio, dwdh, orig_shape):
+        """Scale boxes from letterboxed shape back to original image shape."""
+        boxes[:, [0, 2]] -= dwdh[0]
+        boxes[:, [1, 3]] -= dwdh[1]
+        boxes /= ratio
+        boxes[:, 0::2] = boxes[:, 0::2].clip(0, orig_shape[1])
+        boxes[:, 1::2] = boxes[:, 1::2].clip(0, orig_shape[0])
+        return boxes
+
+    def process_mask(self, protos, masks_in, boxes, orig_shape, ratio, dwdh):
         """Generate masks from mask coefficients and prototypes."""
         c, mh, mw = protos.shape
-        masks = (masks_in @ protos.float().view(c, -1)).view(-1, mh, mw)
-        masks = ops.scale_masks(masks[None], shape)[0]
-        masks = ops.crop_mask(masks, bboxes)
-        return masks.gt_(0.0)
+        masks = masks_in @ protos.reshape(c, -1)
+        masks = 1 / (1 + np.exp(-masks))
+        masks = masks.reshape(-1, mh, mw)
+        masks_resized = []
+        for mask in masks:
+            mask = cv2.resize(mask, self.imgsz[::-1], interpolation=cv2.INTER_LINEAR)
+            dh, dw = dwdh[1], dwdh[0]
+            h, w = int(orig_shape[0] * ratio), int(orig_shape[1] * ratio)
+            mask = mask[int(dh) : int(dh + h), int(dw) : int(dw + w)]
+            mask = cv2.resize(mask, (orig_shape[1], orig_shape[0]), interpolation=cv2.INTER_LINEAR)
+            masks_resized.append(mask)
+        masks_resized = np.stack(masks_resized, axis=0)
+        masks_final = []
+        for mask, box in zip(masks_resized, boxes):
+            x1, y1, x2, y2 = box.astype(int)
+            m = np.zeros_like(mask, dtype=np.uint8)
+            m[y1:y2, x1:x2] = (mask[y1:y2, x1:x2] > 0.5).astype(np.uint8)
+            masks_final.append(m)
+        return np.stack(masks_final, axis=0)
+
+    def draw(self, img, boxes, masks, class_ids, scores):
+        """Draw masks and boxes on image."""
+        colors = np.random.RandomState(42).randint(0, 255, (len(set(class_ids)), 3))
+        for i, box in enumerate(boxes):
+            color = colors[class_ids[i] % len(colors)].tolist()
+            x1, y1, x2, y2 = box.astype(int)
+            cv2.rectangle(img, (x1, y1), (x2, y2), color, 2)
+            mask = masks[i].astype(bool)
+            img[mask] = img[mask] * 0.5 + np.array(color) * 0.5
+            label = f"{class_ids[i]}:{scores[i]:.2f}"
+            cv2.putText(img, label, (x1, y1 - 2), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1, cv2.LINE_AA)
+        return img
 
 
-def main(onnx_model: str, source: str, conf: float = 0.25, iou: float = 0.7) -> List[Results]:
+def main(onnx_model: str, source: str, conf: float = 0.25, iou: float = 0.7):
     """Run YOLO11 segmentation inference using OpenCV."""
     model = YOLO11Seg(onnx_model, conf, iou)
     img = cv2.imread(source)
-    results = model(img)
-    cv2.imshow("Segmented Image", results[0].plot())
-    cv2.waitKey(0)
-    cv2.destroyAllWindows()
-    return results
+    boxes, masks, class_ids, scores = model(img)
+    if len(boxes):
+        result = model.draw(img.copy(), boxes, masks, class_ids, scores)
+        cv2.imshow("Segmented Image", result)
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
+    return boxes, masks, class_ids, scores
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, required=True, help="Path to ONNX model")
-    parser.add_argument("--source", type=str, default=str(ASSETS / "bus.jpg"), help="Path to input image")
+    parser.add_argument("--source", type=str, required=True, help="Path to input image")
     parser.add_argument("--conf", type=float, default=0.25, help="Confidence threshold")
     parser.add_argument("--iou", type=float, default=0.7, help="NMS IoU threshold")
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- add OpenCV DNN-based script for running YOLO11 segmentation ONNX models
- document example usage and setup steps

## Testing
- `python -m py_compile examples/YOLO11-Segmentation-OpenCV-ONNX-Python/main.py`
- `pytest tests/test_cli.py::test_cli_help -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6893f8a0dc9483228a366dfe60bf3e84